### PR TITLE
Allow HTTP URLs

### DIFF
--- a/app/js/components/source.cjsx
+++ b/app/js/components/source.cjsx
@@ -12,7 +12,7 @@ module.exports = XrespondSource = React.createClass
     @publish 'sourceSubmit', @assert_prefix(source_value)
 
   assert_prefix: (url) ->
-    if url.match(/^https/) or url == '' then url else 'https://' + url
+    if url.match(/^http/) or url == '' then url else 'https://' + url
 
   render: ->
     <form className="source-url__wrap" onSubmit={@handleSubmit}>


### PR DESCRIPTION
Allow non-HTTPS URLs (eg. useful for testing dev servers locally). Keeps the default `https` for URLs without a protocol specified.